### PR TITLE
Add reuse license compliance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # EditorConfig is awesome: https://EditorConfig.org
 
 # Top-most EditorConfig file

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 node_modules/
 dist/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 version: 2
 updates:
   - package-ecosystem: npm

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: CI/CD Pipeline
 
 # Trigger the workflow on push or pull request

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 node_modules/
 dist/
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,17 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: inclusiontoolbox
+Source: https://github.com/diggsweden/inclusiontoolbox
+
+Files: package*.json .eslintrc.json .env examples/*.json 
+Copyright: Digg - Agency for Digital Government
+License: CC0-1.0
+
+Files: examples/*.ico docs/Component_diagram_feedback_app_module_in_drop_in_lib.drawio.svg
+Copyright: Digg- Agency for Digital Government
+License: CC0-1.0
+
+# Third-party files
+
+Files: src/assets/fonts/Lato-Regular.ttf
+Copyright: tyPoland Lukasz Dziedzic
+License: OFL-1.1

--- a/LICENSES/OFL-1.1.txt
+++ b/LICENSES/OFL-1.1.txt
@@ -1,0 +1,43 @@
+SIL OPEN FONT LICENSE
+
+Version 1.1 - 26 February 2007
+
+PREAMBLE
+
+The goals of the Open Font License (OFL) are to stimulate worldwide development of collaborative font projects, to support the font creation efforts of academic and linguistic communities, and to provide a free and open framework in which fonts may be shared and improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and redistributed freely as long as they are not sold by themselves. The fonts, including any derivative works, can be bundled, embedded, redistributed and/or sold with any software provided that any reserved names are not used by derivative works. The fonts and derivatives, however, cannot be released under any other type of license. The requirement for fonts to remain under this license does not apply to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+
+"Font Software" refers to the set of files released by the Copyright Holder(s) under this license and clearly marked as such. This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting, or substituting — in part or in whole — any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font Name(s) unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used to promote, endorse or advertise any Modified Version, except to acknowledge the contribution(s) of the Copyright Holder(s) and the Author(s) or with their explicit written permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this license, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.
+
+TERMINATION
+
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ SPDX-License-Identifier: MIT
 
 # InclusionToolbox lib
 
-[![License: MIT](https://img.shields.io/badge/Licence-MIT-yellow)](https://img.shields.io/badge/Licence-MIT-yellow) [![Standard commitment](https://img.shields.io/badge/Standard_for_public_code-commitment-green)](https://img.shields.io/badge/Standard_for_public_code-commitment-green)
+[![License: MIT](https://img.shields.io/badge/Licence-MIT-yellow)](https://img.shields.io/badge/Licence-MIT-yellow)
+
+[![REUSE status](https://api.reuse.software/badge/github.com/diggsweden/inclusiontoolbox)](https://api.reuse.software/info/github.com/diggsweden/inclusiontoolbox)
 
 [![Node: 18.17.0](https://img.shields.io/badge/Node-18.17.0-red)](https://img.shields.io/badge/Node-18.17.0-red)
 

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # Introduction.md
 
 ## The journey to a digitally inclusive society

--- a/examples/supportModal.html
+++ b/examples/supportModal.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 

--- a/examples/userFeedback.html
+++ b/examples/userFeedback.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 

--- a/examples/userFeedback.jsx
+++ b/examples/userFeedback.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import React, { useEffect, useRef } from "react";
 import { UserFeedback } from "path/to/InclusionToolbox";
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * For a detailed explanation regarding each configuration property, visit:
  * https://jestjs.io/docs/configuration

--- a/src/assets/components/iframeElement.js
+++ b/src/assets/components/iframeElement.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import "../css/iframeElement.css";
 
 function IframeElement({

--- a/src/assets/components/supportModalElement.js
+++ b/src/assets/components/supportModalElement.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import "../css/base.css";
 import "../css/supportModalElement.css";
 import "../fonts/Lato-Regular.ttf";

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 @font-face {
 	font-family: 'Lato';
 	src: local('Lato');

--- a/src/assets/css/iframeElement.css
+++ b/src/assets/css/iframeElement.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 /**
  * iframe element styles for inclusion toolbox
  */

--- a/src/assets/css/supportModalElement.css
+++ b/src/assets/css/supportModalElement.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 /**
 * Reset Button
 */

--- a/src/assets/translations.js
+++ b/src/assets/translations.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 const translations = {
 	en: { translation: { help: "Help" } },
 	es: { translation: { help: "Ayuda" } },

--- a/src/embed/iframe/iframeHandler.js
+++ b/src/embed/iframe/iframeHandler.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import PostMessageHandler from "./postMessageHandler.js";
 import IframeElement from "../../assets/components/iframeElement.js";
 

--- a/src/embed/iframe/postMessageHandler.js
+++ b/src/embed/iframe/postMessageHandler.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /* PostMessageHandler
  * A class to handle communication via postMessage
  *

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import '@util/i18n.js';
 import UserFeedback from '@service/userFeedback/userFeedback.js';
 import SupportModal from '@service/supportModal/supportModal.js';

--- a/src/service/supportModal/messageHandlers.js
+++ b/src/service/supportModal/messageHandlers.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * Message handlers for the embed iframe.
  *

--- a/src/service/supportModal/supportModal.js
+++ b/src/service/supportModal/supportModal.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import IframeHandler from "@embed/iframe/iframeHandler.js";
 import ConfigManager from "@util/configManager.js";
 import getFingerprint from "@util/fingerprint.js";

--- a/src/service/userFeedback/messageHandlers.js
+++ b/src/service/userFeedback/messageHandlers.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * Message handlers for the embed iframe.
  *

--- a/src/service/userFeedback/userFeedback.js
+++ b/src/service/userFeedback/userFeedback.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import IframeHandler from "@embed/iframe/iframeHandler.js";
 import getFingerprint from "@util/fingerprint.js";
 import messageHandlers from "./messageHandlers.js";

--- a/src/util/configManager.js
+++ b/src/util/configManager.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 const DEFAULT_CONFIG_PREFIX = process.env.CONFIG_PREFIX || "INCLUSION_TOOLBOX_";
 /*
  * This is a singleton class that manages long lived configuration for the application.

--- a/src/util/fingerprint.js
+++ b/src/util/fingerprint.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { getCurrentBrowserFingerPrint } from "@rajesh896/broprint.js";
 
 /**

--- a/src/util/i18n.js
+++ b/src/util/i18n.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import i18next from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import translations from "../assets/translations.js";

--- a/test/assets/components/supportModalElement.test.js
+++ b/test/assets/components/supportModalElement.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import SupportModalElement from "@src/assets/components/supportModalElement.js";
 
 /**

--- a/test/embed/iframe/iFrameHandler.test.js
+++ b/test/embed/iframe/iFrameHandler.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import IframeHandler from "@src/embed/iframe/iframeHandler.js";
 
 /**

--- a/test/embed/iframe/postMessageHandler.test.js
+++ b/test/embed/iframe/postMessageHandler.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import PostMessageHandler from "@src/embed/iframe/postMessageHandler.js";
 
 /**

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import {
 	jest,
 	describe,

--- a/test/service/supportModal/supportModal.test.js
+++ b/test/service/supportModal/supportModal.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import SupportModal from "@src/service/supportModal/supportModal.js";
 import IframeHandler from "@embed/iframe/iframeHandler.js";
 import ConfigManager from "@util/configManager.js";

--- a/test/service/userFeedback/messageHandlers.test.js
+++ b/test/service/userFeedback/messageHandlers.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import messageHandlers from "@src/service/userFeedback/messageHandlers.js";
 
 /**

--- a/test/service/userFeedback/userFeedback.test.js
+++ b/test/service/userFeedback/userFeedback.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import UserFeedback from "@src/service/userFeedback/userFeedback.js";
 
 /**

--- a/test/service/util/configManager.test.js
+++ b/test/service/util/configManager.test.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import ConfigManager from "@src/util/configManager.js";
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import path from "path";
 import { fileURLToPath } from "url";
 import Dotenv from "dotenv-webpack";


### PR DESCRIPTION
This PR makes the project license declare licenses according to https://reuse.software/ so that it passes the reuse lint.

Even though it is many affected files, the pr is scroll friendly and contains no logic. It should hopefully be a quick general overview before merging it.

Basically, it adds license headers in spdx-format, as per the reuse-specification. It also adds a missing reuse LICENSES file, ofl 1.1, and the .reuse/dep5 which takes care of the licening of json files etc.

Note: the reuse badge in the README will be green when the project is public

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
